### PR TITLE
feat: add destination parameter to openWidget() API

### DIFF
--- a/android/src/main/java/com/celloreactnative/CelloReactNativeModule.kt
+++ b/android/src/main/java/com/celloreactnative/CelloReactNativeModule.kt
@@ -101,9 +101,9 @@ class CelloReactNativeModule(reactContext: ReactApplicationContext) :
   }
 
   @ReactMethod
-  fun openWidget() {
+  fun openWidget(destination: String?) {
     try {
-      Cello.client()?.openWidget()
+      Cello.client()?.openWidget(destination = destination)
     } catch (e: Exception) {
 
     }

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,6 +2,7 @@ import Cello, { CelloEvents } from '@getcello/cello-react-native';
 import React, { useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 import {
+  Button,
   SafeAreaView,
   ScrollView,
   StatusBar,
@@ -106,6 +107,26 @@ function App(): JSX.Element {
           <Section title="Debug">
             <DebugInstructions />
           </Section>
+          <Section title="Open Widget">
+            <View style={styles.buttonGroup}>
+              <Button
+                title="Open Widget"
+                onPress={() => Cello.openWidget()}
+              />
+              <View style={styles.buttonSpacer} />
+              <Button
+                title="Open Rewards"
+                onPress={() => Cello.openWidget('rewards')}
+                color="#6200ee"
+              />
+              <View style={styles.buttonSpacer} />
+              <Button
+                title="Open Edit Payments"
+                onPress={() => Cello.openWidget('edit-payments')}
+                color="#03dac6"
+              />
+            </View>
+          </Section>
           <Section title="Learn More">
             Read the docs to discover what to do next:
           </Section>
@@ -132,6 +153,13 @@ const styles = StyleSheet.create({
   },
   highlight: {
     fontWeight: '700',
+  },
+  buttonGroup: {
+    marginTop: 12,
+    gap: 8,
+  },
+  buttonSpacer: {
+    height: 8,
   },
 });
 

--- a/ios/CelloReactNative.mm
+++ b/ios/CelloReactNative.mm
@@ -27,7 +27,7 @@ RCT_EXTERN_METHOD(showFab)
 
 RCT_EXTERN_METHOD(hideFab)
 
-RCT_EXTERN_METHOD(openWidget)
+RCT_EXTERN_METHOD(openWidget:(nullable NSString *)destination)
 
 RCT_EXTERN_METHOD(hideWidget)
 

--- a/ios/CelloReactNative.swift
+++ b/ios/CelloReactNative.swift
@@ -88,9 +88,9 @@ class CelloReactNative: NSObject {
     Cello.hideFab()
   }
 
-  @objc(openWidget)
-  func openWidget() -> Void {
-    Cello.openWidget()
+  @objc(openWidget:)
+  func openWidget(destination: String?) -> Void {
+    Cello.openWidget(destination: destination)
   }
 
   @objc(hideWidget)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -99,8 +99,8 @@ function hideFab() {
   return CelloReactNative.hideFab();
 }
 
-function openWidget() {
-  return CelloReactNative.openWidget();
+function openWidget(destination?: string) {
+  return CelloReactNative.openWidget(destination);
 }
 
 function hideWidget() {


### PR DESCRIPTION
Add support for opening the widget on a specific tab/page, matching the web SDK's open(destination) API.

Supported destinations:
- "rewards" - opens the rewards tab
- "edit-payments" - opens the payment details page

Changes:
- src/index.tsx: openWidget(destination?) accepts optional destination string
- iOS bridge: CelloReactNative.swift/.mm updated to pass destination to native SDK
- Android bridge: CelloReactNativeModule.kt updated to pass destination to native SDK
- Example app: Added test buttons for default, rewards, and edit-payments